### PR TITLE
Post+PostList: Add tags data to Posts

### DIFF
--- a/posts/posts.go
+++ b/posts/posts.go
@@ -1,6 +1,10 @@
 package posts
 
-import "html/template"
+import (
+	"fmt"
+	"html/template"
+	"strings"
+)
 
 type Post struct {
 	Content template.HTML
@@ -8,6 +12,15 @@ type Post struct {
 	Title   string
 	Posted  string
 	Updated string
+	Tags    []string
+}
+
+func (p Post) RenderTags() string {
+	if p.Tags == nil {
+		return ""
+	}
+
+	return fmt.Sprintf("[%s]", strings.Join(p.Tags, ", "))
 }
 
 var (
@@ -20,66 +33,77 @@ var (
 		Path:   "notes/1-mountain-goats.html",
 		Title:  "Mountain Goats",
 		Posted: "2021-04-14",
+		Tags:   []string{"allegory"},
 	}
 	Ackermann = Post{
 		Path:    "notes/2-ackerman-function-expansions.html",
 		Title:   "Ackermann Function Expansions",
 		Posted:  "2021-04-16",
 		Updated: "2021-04-16",
+		Tags:    []string{"programming", "lisp"},
 	}
 	GoodAdvice = Post{
 		Path:    "notes/3-good-advice.html",
 		Title:   "Guy Clark On Good Advice",
 		Posted:  "2021-04-19",
 		Updated: "2021-04-20",
+		Tags:    []string{"music"},
 	}
 	MatchingParens = Post{
 		Path:    "notes/4-matching-parens.html",
 		Title:   "Matching Parens",
 		Posted:  "2021-04-30",
 		Updated: "2021-04-30",
+		Tags:    []string{"programming", "lisp"},
 	}
 	PeppersIntro = Post{
 		Path:    "notes/5-peppers-intro.html",
 		Title:   "Peppers Intro",
 		Posted:  "2021-08-01",
 		Updated: "2021-10-15",
+		Tags:    []string{"peppers", "gardening"},
 	}
 	MutableCallArgsInPython = Post{
 		Path:    "notes/6-mutable-call-args-in-python.html",
 		Title:   "Mutable Call Arguments in Python",
 		Posted:  "2021-08-25",
 		Updated: "2021-12-05",
+		Tags:    []string{"programming"},
 	}
 	PeppersPartTwo = Post{
 		Path:    "notes/7-peppers-part-2.html",
 		Title:   "Peppers Part 2: The Flowering",
 		Posted:  "2021-09-22",
 		Updated: "2021-10-15",
+		Tags:    []string{"peppers", "gardening"},
 	}
 	ModernFrontendProblems = Post{
 		Path:    "notes/8-the-problem-with-modern-web-development.html",
 		Title:   "The Problem With Modern Web Development",
 		Posted:  "2021-09-22",
 		Updated: "2021-10-09",
+		Tags:    []string{"programming"},
 	}
 	CoffeeFromAnOldCoworker = Post{
 		Path:    "notes/9-maple-leaf-coffee-nicaraguan-el-finca.html",
 		Title:   "Coffee From an Old Coworker",
 		Posted:  "2021-10-01",
 		Updated: "2021-10-09",
+		Tags:    []string{"coffee"},
 	}
 	PeppersPartThree = Post{
 		Path:    "notes/10-peppers-part-3-fruits.html",
 		Title:   "Peppers Part 3: Fruits",
 		Posted:  "2021-10-10",
 		Updated: "2021-10-15",
+		Tags:    []string{"peppers", "gardening"},
 	}
 	AlacrittySpawnNewWindow = Post{
 		Path:    "notes/11-alacritty-spawn-new-window.html",
 		Title:   "Spawning New Windows in Alacritty (On Fedora 35)",
 		Posted:  "2021-12-04",
 		Updated: "2021-12-07",
+		Tags:    []string{"programming"},
 	}
 
 	Posts = []Post{

--- a/templates/notes/l.html
+++ b/templates/notes/l.html
@@ -7,7 +7,7 @@
   </em>
   <ul>
 	{{- range $post := .Other.Posts -}}
-    <li><a href="/{{$post.Path}}">{{$post.Title}}</a> <em>@{{$post.Posted}}{{if $post.Updated}},*{{$post.Updated}}{{end}}</em> </li>
+    <li><a href="/{{$post.Path}}">{{$post.Title}}</a> {{$post.RenderTags}} <em>@{{$post.Posted}}{{if $post.Updated}},*{{$post.Updated}} {{end}}</em> </li>
 	{{- end -}}
   </ul>
 </div>

--- a/templates/notes/note.html
+++ b/templates/notes/note.html
@@ -1,6 +1,9 @@
 {{define "notes-note"}}
 <section id="post">
   <h3>{{- .Other.Title }} </h3>
+  {{ .Other.RenderTags }}
+  <br>
+  <br>
   <em class="small-em">@{{ .Other.Posted -}}</em>
   {{- if .Other.Updated -}}
   <em class="small-em">,*{{ .Other.Updated -}}</em>


### PR DESCRIPTION
Right now, we just render them on `notes/l.html` and `notes/{note}` page, but we can do more fun things with this, like build an index of posts by Tags. We'll see.