### PR TITLE
Change code-block background color to a dark grey

### DIFF
--- a/templates/common.js
+++ b/templates/common.js
@@ -5,11 +5,13 @@ const cssMappings = {
     "--link-text-color": "white",
     "--link-text-hover-color": "teal",
     "--background-color": "#02071f",
+    "--code-block-background-color": "#1e1b1b",
   },
   light: {
     "--link-text-color": "#02071f",
     "--link-text-hover-color": "#db4e4e",
     "--background-color": "white",
+    "--code-block-background-color": "#1e1b1b",
   },
 };
 

--- a/templates/post.css
+++ b/templates/post.css
@@ -13,7 +13,7 @@
 
 #post pre {
 	font-size: 16px;
-	background-color: #02071f;
+	background-color: var(--code-block-background-color);
 	color: limegreen;
 	overflow: scroll;
 	padding: 5px;


### PR DESCRIPTION
We also move its definition to CSS variable so that it can be dynamically changed between light and dark modes. We set it to the same value though, for now, since it looks good in light and dark.